### PR TITLE
Uncomment the code to load a prototype file if it exists.

### DIFF
--- a/src/main/java/org/vorthmann/zome/app/impl/ApplicationController.java
+++ b/src/main/java/org/vorthmann/zome/app/impl/ApplicationController.java
@@ -239,8 +239,8 @@ public class ApplicationController extends DefaultController
                 String fieldName = action .substring( "new-" .length() );
                 File prototype = new File( Platform .getPreferencesFolder(), "Prototypes/" + fieldName + ".vZome" );
                 if ( prototype .exists() ) {
-//		            	this .mController .doAction(action, e);
-//		                doFileAction( "newFromTemplate", prototype );
+                    logger.log(Level.CONFIG, "Loading default template from {0}", prototype.getCanonicalPath());
+                    doFileAction( "newFromTemplate", prototype );
                 }
                 else
                 {

--- a/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -216,18 +216,40 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
                     break;
 
             	case "saveDefault":
-                    // this is basically "save a copy...", with no choosing
+                    // this is basically "save a copy...", with a hard coded file path.
                     String fieldName = mController.getProperty( "field.name" );
                     File prototype = new File( Platform.getPreferencesFolder(), "Prototypes/" + fieldName + ".vZome" );
-                    String msg = "Saving default template";
                     try {
-                        msg = msg + " to " + prototype.getCanonicalPath();
+                        String path = prototype.getCanonicalPath();
+                        int response = JOptionPane.showConfirmDialog(
+                                DocumentFrame.this,
+                                "Do you want to save this model as the default template to be used for new " + fieldName + " models?"
+                                + "\n\nTemplate file: " + path,
+                                "Save Template?",
+                                JOptionPane.YES_NO_OPTION,
+                                JOptionPane.WARNING_MESSAGE );
+                        
+                        if ( response == JOptionPane.YES_OPTION ) {
+                            logger.config("Saving default template to " + path);
+                            mController .doFileAction( "save", prototype );
+                        } 
+                        else if ( prototype.exists() ) {
+                            response = JOptionPane.showConfirmDialog(
+                                DocumentFrame.this,
+                                "Do you want to delete the existing template for new " + fieldName + " models?"
+                                + "\n\nTemplate file: " + path,
+                                "Delete Template?",
+                                JOptionPane.YES_NO_OPTION,
+                                JOptionPane.WARNING_MESSAGE );
+
+                            if ( response == JOptionPane.YES_OPTION ) {
+                                logger.config("Deleting default template at " + path);
+                                prototype.delete();
+                            }
+                        }
                     } catch (IOException ex) {
                         errors .reportError( Controller.USER_ERROR_CODE, new Object[]{ ex } );
                     }
-                    logger.config(msg);
-                    mController .doFileAction( "save", prototype );
-                    JOptionPane.showMessageDialog( null, msg, "Saved Template", JOptionPane.PLAIN_MESSAGE );
                     break;
                     
             	case "snapshot.2d":

--- a/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
+++ b/src/main/java/org/vorthmann/zome/ui/DocumentFrame.java
@@ -45,6 +45,7 @@ import org.vorthmann.ui.Controller;
 import org.vorthmann.ui.ExclusiveAction;
 
 import com.vzome.desktop.controller.ViewPlatformControlPanel;
+import java.io.IOException;
 import static org.vorthmann.zome.ui.ApplicationUI.getLogFileName;
 
 public class DocumentFrame extends JFrame implements PropertyChangeListener, ControlActions
@@ -218,7 +219,15 @@ public class DocumentFrame extends JFrame implements PropertyChangeListener, Con
                     // this is basically "save a copy...", with no choosing
                     String fieldName = mController.getProperty( "field.name" );
                     File prototype = new File( Platform.getPreferencesFolder(), "Prototypes/" + fieldName + ".vZome" );
+                    String msg = "Saving default template";
+                    try {
+                        msg = msg + " to " + prototype.getCanonicalPath();
+                    } catch (IOException ex) {
+                        errors .reportError( Controller.USER_ERROR_CODE, new Object[]{ ex } );
+                    }
+                    logger.config(msg);
                     mController .doFileAction( "save", prototype );
+                    JOptionPane.showMessageDialog( null, msg, "Saved Template", JOptionPane.PLAIN_MESSAGE );
                     break;
                     
             	case "snapshot.2d":


### PR DESCRIPTION
* Log when a prototype file is used or saved.
* Add dialog to notify the user when and where a template file is saved.
* Related bug found in vzome-core while testing this fix, but the two fixes are independent of one another.