### PR TITLE
Repeat the first outline vertex at the end to complete the outline

### DIFF
--- a/src/main/java/org/vorthmann/zome/render/java3d/Java3dFactory.java
+++ b/src/main/java/org/vorthmann/zome/render/java3d/Java3dFactory.java
@@ -123,6 +123,10 @@ public class Java3dFactory implements RenderingViewer.Factory, J3dComponentFacto
             int i = 0;
             for (Face face : faces) {
                 int arity = face .size();
+                if(face.get(0) != face.get(arity-1)) {
+                    // make room for one more vertex at the end to close the outline
+                    arity++;
+                }
                 counts[i++] = arity;
                 numIndices += arity;
             }
@@ -140,6 +144,11 @@ public class Java3dFactory implements RenderingViewer.Factory, J3dComponentFacto
                 int arity = face .size();
                 for ( int j = 0; j < arity; j++ ){
                     Integer index = face .get( j );
+                    strips .setCoordinateIndex(i++, index);
+                }
+                if(face.get(0) != face.get(arity-1)) {
+                    // repeat the first vertex at the end to complete the outline.
+                    Integer index = face .get( 0 );
                     strips .setCoordinateIndex(i++, index);
                 }
             }


### PR DESCRIPTION
* Fixes a rendering bug that is evident by viewing one end of most struts when balls are hidden. Some outline edged are missing in this case.
* It also shows up quite plainly when viewing the "invisible side" of panels with RenderedModel.oneSidedPanels = true.
* A panel from connector A to B to C would previously only draw the outline from A to B to C. This new code closes the loop by adding one more line from C to A. Similar problems occurs with the end of some struts.