### PR TITLE
Add option to use system clipboard for copy and paste.

### DIFF
--- a/src/main/java/org/vorthmann/zome/app/impl/ClipboardController.java
+++ b/src/main/java/org/vorthmann/zome/app/impl/ClipboardController.java
@@ -1,0 +1,52 @@
+package org.vorthmann.zome.app.impl;
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.ClipboardOwner;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.IOException;
+
+/**
+ * @author David Hall
+ */
+public class ClipboardController implements ClipboardOwner {
+    /**
+     * Empty implementation of the ClipboardOwner interface.
+     */
+    @Override
+    public void lostOwnership(Clipboard clipboard, Transferable contents) {
+        //do nothing
+    }
+
+    /**
+     * Place a String on the clipboard, and make this class the owner of the Clipboard's contents.
+     */
+    public void setClipboardContents(String string) {
+        StringSelection stringSelection = new StringSelection(string);
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        clipboard.setContents(stringSelection, this);
+    }
+
+    /**
+     * Get the String residing on the clipboard.
+     *
+     * @return any text found on the Clipboard; if none found, return an empty String.
+     */
+    public String getClipboardContents() {
+        String result = "";
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        //odd: the Object param of getContents is not currently used
+        Transferable contents = clipboard.getContents(null);
+        if( (contents != null) && contents.isDataFlavorSupported(DataFlavor.stringFlavor) ) {
+            try {
+                result = (String) contents.getTransferData(DataFlavor.stringFlavor);
+            } catch (UnsupportedFlavorException | IOException ex) {
+                ex.printStackTrace();
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -143,6 +143,7 @@ public class DocumentController extends DefaultController implements J3dComponen
 
     private Map<String,SymmetryController> symmetries = new HashMap<>();
 
+    private final ClipboardController systemClipboard;
     private String designClipboard;
 
     private boolean editingModel;
@@ -191,6 +192,10 @@ public class DocumentController extends DefaultController implements J3dComponen
         startReader = ! newDocument && ! asTemplate;
         
         editingModel = super.userHasEntitlement( "model.edit" ) ;//&& ! propertyIsTrue( "reader.preview" );
+        
+        systemClipboard = propertyIsTrue( "enable.system.clipboard" )
+                ? new ClipboardController()
+                : null;
         
         toolsController = new ToolsController( document );
         toolsController .setNextController( this );
@@ -1267,8 +1272,10 @@ public class DocumentController extends DefaultController implements J3dComponen
         }
         
         if ( "clipboard" .equals( string ) )
-            return designClipboard;
-                
+            return systemClipboard != null
+                    ? systemClipboard.getClipboardContents()
+                    : designClipboard;
+        
         if ( "showFrameLabels" .equals( string ) )
             return Boolean .toString( showFrameLabels );
                 
@@ -1395,8 +1402,14 @@ public class DocumentController extends DefaultController implements J3dComponen
             this.showStrutScales = "true" .equals( value );
             properties().firePropertyChange( "showStrutScales", old, this.showStrutScales );
         }
-        else if ( "clipboard" .equals( cmd ) )
-            this .designClipboard = (String) value;
+        else if ( "clipboard" .equals( cmd ) ) {
+            if( systemClipboard != null ) {
+                systemClipboard.setClipboardContents((String) value);
+            }
+            else {
+                designClipboard = (String) value;
+            }
+        }
         
         else if ( "showFrameLabels" .equals( cmd ) )
         {

--- a/src/test/java/org/vorthmann/zome/app/impl/ClipboardControllerTest.java
+++ b/src/test/java/org/vorthmann/zome/app/impl/ClipboardControllerTest.java
@@ -1,0 +1,47 @@
+package org.vorthmann.zome.app.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+/**
+ *
+ * @author David Hall
+ */
+public class ClipboardControllerTest {
+
+    private static final String NULL_TEXT = "<null>";
+    @Test
+    public void testTextTransfer() {
+        System.out.println("testTextTransfer");
+        ClipboardController clipboard = new ClipboardController();
+        
+        String content = getClipboardContent(clipboard);
+        assertNotNull(content);
+
+        content = null;
+        clipboard.setClipboardContents(content);        
+        String result = getClipboardContent(clipboard);
+        assertEquals(NULL_TEXT, result);
+
+        String delim = "";
+        StringBuffer sb = new StringBuffer("");
+        for( int i = 0; i <= 16; i++) {
+            sb.append(delim).append(i);
+            delim = ", ";
+            content = sb.toString();
+            clipboard.setClipboardContents(content);
+            result = getClipboardContent(clipboard);
+            assertEquals(content, result);
+        }
+    }
+
+    private static String getClipboardContent(ClipboardController clipboard) {
+        String content = clipboard.getClipboardContents();
+        if(content == null) {
+            content = NULL_TEXT;
+        }
+        System.out.println("Clipboard contains:\n" + content + "\n");
+        return content;
+    }
+}


### PR DESCRIPTION
* Controlled by enable.system.clipboard=true in preferences file.
* Defaults to the original behavior (not using system clipboard)
* No ClipboardController even gets created if the feature is not enabled.

When I realized that you were using a VEF string for implementing your internal clipboard, I thought it might be helpful to quickly capture the selection to the system clipboard instead of just an internal String variable. Then I can paste it to a text editor while I'm working on getting the VEF export to be in canonically sorted order. I found an example of using the system clipboard in java and integrated it along with a quick test case. Hope you like it.