### PR TITLE
BMP Image compression

### DIFF
--- a/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -1000,10 +1000,11 @@ public class DocumentController extends DefaultController implements J3dComponen
                 File dir = file .getParentFile();
                 if ( ! dir .exists() )
                     dir .mkdirs();
-                
-                FileOutputStream out = new FileOutputStream( file );
-                documentModel .serialize( out, this .properties );
-                out.close();
+
+                // A try-with-resources block closes the resource even if an exception occurs
+                try (FileOutputStream out = new FileOutputStream( file )) {
+                    documentModel .serialize( out, this .properties );
+                }
                 // just did a save, so lets record the document change count again,
                 //  so isEdited() will return false until more changes occur.
                 // IMPORTANT! TODO if we ever implement "save a copy", this code should NOT reset
@@ -1229,15 +1230,11 @@ public class DocumentController extends DefaultController implements J3dComponen
 
     private static void writeFile( String content, File file ) throws Exception
     {
-        FileWriter writer = null;
-        try {
-            writer = new FileWriter( file );
+        // A try-with-resources block closes the resource even if an exception occurs
+        try (FileWriter writer = new FileWriter( file )) {
             writer .write( content );
         } catch (Exception ex) {
             throw ex;
-        } finally {
-            if(writer != null)
-                writer .close();
         }
     }
 

--- a/src/main/java/org/vorthmann/zome/export/java2d/Java2dSnapshot.java
+++ b/src/main/java/org/vorthmann/zome/export/java2d/Java2dSnapshot.java
@@ -147,18 +147,26 @@ public class Java2dSnapshot extends DefaultController
     public void doFileAction( String command, File file )
     {
         try {
-            SnapshotExporter exporter = null;
-            if ( command .equals( "export.2d.pdf" ) )
-                exporter = new PDFExporter();
-            else if ( command .equals( "export.2d.ps" ) )
-                exporter = new PostScriptExporter();
-            else if ( command .equals( "export.2d.svg" ) )
-                exporter = new SVGExporter();
-            if ( exporter == null )
+            SnapshotExporter snapshotExporter = null;
+            switch (command) {
+                case "export.2d.pdf":
+                    snapshotExporter = new PDFExporter();
+                    break;
+                case "export.2d.ps":
+                    snapshotExporter = new PostScriptExporter();
+                    break;
+                case "export.2d.svg":
+                    snapshotExporter = new SVGExporter();
+                    break;
+                default:
+                    break;
+            }
+            if ( snapshotExporter == null )
                 return;
-            Writer out = new FileWriter( file );
-            exporter .export( this, out );
-            out .close();
+            // A try-with-resources block closes the resource even if an exception occurs
+            try (Writer out = new FileWriter( file )) {
+                snapshotExporter .export( this, out );
+            }
             openApplication( file );
         } catch ( Exception e ) {
             mErrors .reportError( UNKNOWN_ERROR_CODE, new Object[]{ e } );

--- a/src/main/java/org/vorthmann/zome/ui/PythonConsolePanel.java
+++ b/src/main/java/org/vorthmann/zome/ui/PythonConsolePanel.java
@@ -128,10 +128,9 @@ public class PythonConsolePanel extends JPanel implements Tool {
 		String fileName = mFileChooser .getFile();
 		if ( fileName != null ) {
 			File file = new File( mFileChooser .getDirectory(), fileName );
-            try {
-                Writer out = new FileWriter( file );
+            // A try-with-resources block closes the resource even if an exception occurs
+            try (Writer out = new FileWriter( file )) {
                 out .write( script );
-                out .close();
             }
             catch (Exception exc) {
                 JOptionPane .showMessageDialog( PythonConsolePanel.this,

--- a/src/main/java/org/vorthmann/zome/ui/ZomicEditorPanel.java
+++ b/src/main/java/org/vorthmann/zome/ui/ZomicEditorPanel.java
@@ -155,10 +155,9 @@ public class ZomicEditorPanel extends JPanel implements Tool {
 		String fileName = mFileChooser .getFile();
 		if ( fileName != null ) {
 			File file = new File( mFileChooser .getDirectory(), fileName );
-            try {
-                Writer out = new FileWriter( file );
+            // A try-with-resources block closes the resource even if an exception occurs
+            try (Writer out = new FileWriter( file )) {
                 out .write( script );
-                out .close();
             }
             catch (Exception exc) {
                 JOptionPane .showMessageDialog( ZomicEditorPanel.this,


### PR DESCRIPTION
Changed the default image compression format for BMP files so they will open in Windows 10.

The old code just tried to use the last valid compression format for an image. This new version explicitly specifies the desired format from the list that is available in the Windows JRE.

The BMP image capture should be the only compression format to be affected by this change, but please try all 4 formats and be sure they still work on a MAC.

I also switched to try-with-resources blocks wherever possible because it automatically closes the resources even if an exception occurs. 
