### PR TITLE
Initialize DocumentController.properties earlier in the constructor.

### DIFF
--- a/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
+++ b/src/main/java/org/vorthmann/zome/app/impl/DocumentController.java
@@ -177,11 +177,13 @@ public class DocumentController extends DefaultController implements J3dComponen
 
     public DocumentController( DocumentModel document, ApplicationController app, Properties props )
     {
-        setNextController( app );
-
+        // initialize this.properties before calling setNextController()
+        // so it can safely call getProperty()
         this .properties = props;
         this .documentModel = document;
         
+        setNextController( app );
+   
         if ( this .documentModel .isMigrated() )
             this .changeCount = -1; // this will force isEdited() to return true
 


### PR DESCRIPTION
* Avoids possible NPE if setNextController calls getProperty()

No current issue with this, but it's a simple change that affects another branch and I'd like to get this part in master independently.